### PR TITLE
Do not display tabs as special chars in the .gitmodules config file.

### DIFF
--- a/after/ftplugin/gitconfig.vim
+++ b/after/ftplugin/gitconfig.vim
@@ -1,0 +1,2 @@
+"Do not replace tabs by special characters in git configuration files.
+autocmd BufEnter .gitmodules setlocal listchars=tab:\ \ ,trail:·,nbsp:~"


### PR DESCRIPTION
.gitmodules files are auto generated and make use of tabulators.